### PR TITLE
feat: add browser support

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 coverage
 dist
+dist.browser

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist
+dist.browser
 node_modules
 coverage
 .env

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 coverage
 dist
+dist.browser

--- a/package.json
+++ b/package.json
@@ -18,13 +18,14 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "files": [
-    "dist"
+    "dist",
+    "dist.browser"
   ],
   "scripts": {
     "audit": "audit-ci --moderate",
     "prepare": "npm run build",
-    "build": "npm run clean && tsc -p tsconfig.build.json",
-    "clean": "rm -rf ./dist ./coverage",
+    "build": "npm run clean && tsc -p tsconfig.build.json && tsc -p tsconfig.browser.json",
+    "clean": "rm -rf ./dist ./dist.browser ./coverage",
     "compile": "tsc",
     "compile:dev": "tsc -w",
     "coverage": "jest --coverage",

--- a/src/SiopDidAuth.ts
+++ b/src/SiopDidAuth.ts
@@ -269,13 +269,19 @@ const verifyDidAuthRequest = async (
   );
   if (!verificationMethod)
     throw new Error(DidAuthErrors.VERIFICATION_METHOD_NOT_MATCHES);
+  try {
+    // Verify the SIOP Request according to the verification method above.
+    const verification = await util.verifySignatureFromVerificationMethod(
+      jwt,
+      verificationMethod
+    );
+    if (!verification) throw Error(DidAuthErrors.ERROR_VERIFYING_SIGNATURE);
+  } catch (error) {
+    throw Error(
+      DidAuthErrors.ERROR_VERIFYING_SIGNATURE + (error as Error).message
+    );
+  }
 
-  // Verify the SIOP Request according to the verification method above.
-  const verification = await util.verifySignatureFromVerificationMethod(
-    jwt,
-    verificationMethod
-  );
-  if (!verification) throw Error(DidAuthErrors.ERROR_VERIFYING_SIGNATURE);
   // Additionally performs a complete token validation via vidVerifyJwt
   return verifyDidAuth(jwt, opts);
 };

--- a/src/util/Util.ts
+++ b/src/util/Util.ts
@@ -192,40 +192,32 @@ const verifyES256K = (
   jwt: string,
   verificationMethod: VerificationMethod
 ): boolean => {
-  try {
-    const publicKey = extractPublicKeyBytes(verificationMethod);
-    const secp256k1 = new EC("secp256k1");
-    const { data, signature } = decodeJwt(jwt);
-    const hash = SHA("sha256").update(data).digest();
-    const sigObj = toSignatureObject(signature);
-    return secp256k1.keyFromPublic(publicKey, "hex").verify(hash, sigObj);
-  } catch (err) {
-    return false;
-  }
+  const publicKey = extractPublicKeyBytes(verificationMethod);
+  const secp256k1 = new EC("secp256k1");
+  const { data, signature } = decodeJwt(jwt);
+  const hash = SHA("sha256").update(data).digest();
+  const sigObj = toSignatureObject(signature);
+  return secp256k1.keyFromPublic(publicKey, "hex").verify(hash, sigObj);
 };
 
 const verifyEDDSA = async (
   jwt: string,
   verificationMethod: VerificationMethod
 ): Promise<boolean> => {
-  try {
-    let publicKey: JWK;
-    if (verificationMethod.publicKeyBase58)
-      publicKey = keyUtils.publicKeyJwkFromPublicKeyBase58(
-        verificationMethod.publicKeyBase58
-      );
-    if (verificationMethod.publicKeyJwk)
-      publicKey = verificationMethod.publicKeyJwk;
-    const result = await jwtVerify(
-      jwt,
-      await parseJwk(publicKey, DidAuthKeyAlgorithm.EDDSA)
+  let publicKey: JWK;
+  if (verificationMethod.publicKeyBase58)
+    publicKey = keyUtils.publicKeyJwkFromPublicKeyBase58(
+      verificationMethod.publicKeyBase58
     );
-    if (!result || !result.payload)
-      throw Error(DidAuthErrors.ERROR_VERIFYING_SIGNATURE);
-    return true;
-  } catch (err) {
-    return false;
-  }
+  if (verificationMethod.publicKeyJwk)
+    publicKey = verificationMethod.publicKeyJwk;
+  const result = await jwtVerify(
+    jwt,
+    await parseJwk(publicKey, DidAuthKeyAlgorithm.EDDSA)
+  );
+  if (!result || !result.payload)
+    throw Error(DidAuthErrors.ERROR_VERIFYING_SIGNATURE);
+  return true;
 };
 
 const verifySignatureFromVerificationMethod = async (

--- a/tsconfig.browser.json
+++ b/tsconfig.browser.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "declaration": true,
+    "sourceMap": true,
+    "incremental": true,
+    "strict": false,
+    "outDir": "./dist.browser",
+    "target": "es5",
+    "module": "es2015",
+    "moduleResolution": "node",
+    "lib": ["es2016", "dom", "es5"]
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
- Add support to browser.
- Now prints the error when signature verification fails

To use it on a browser import from `dist.browser` directory

Added a `tsconfig.browser.json` when building the library